### PR TITLE
Fix C++ compatibility with glib 2.67.3.

### DIFF
--- a/src/autotrace.h
+++ b/src/autotrace.h
@@ -23,6 +23,9 @@
 
 #include <stdio.h>
 
+#include "types.h"
+#include "color.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif                          /* __cplusplus */
@@ -34,9 +37,6 @@ extern "C" {
 /* ===================================================================== *
  * Typedefs
  * ===================================================================== */
-
-#include "types.h"
-#include "color.h"
 
 /* Third degree is the highest we deal with.  */
   enum _at_polynomial_degree {

--- a/src/color.h
+++ b/src/color.h
@@ -24,6 +24,10 @@
 #include <glib.h>
 #include <glib-object.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif                          /* __cplusplus */
+
 typedef struct _at_color at_color;
 struct _at_color {
   guint8 r;
@@ -43,4 +47,7 @@ void at_color_free(at_color * color);
 GType at_color_get_type(void);
 #define AT_TYPE_COLOR (at_color_get_type ())
 
+#ifdef __cplusplus
+}
+#endif                          /* __cplusplus */
 #endif /* not AT_COLOR_H */


### PR DESCRIPTION
As of glib 2.67.3, <glib.h> can no longer be included in extern "C"
blocks. It was indirectly included by both "types.h" and "color.h".
"types.h" already does not need to be wrapped in an extern "C" block,
"color.h" does but can be modified not to, so with that changed they can
be moved out.